### PR TITLE
Add TLS Version header

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 )
 
-var errMissingHeaderConfig = errors.New("missing header config: must set headers.cipher")
+var errMissingHeaderConfig = errors.New("missing header config: must set headers.version or headers.cipher")
 
 // Config the plugin configuration.
 type Config struct {
@@ -18,6 +18,7 @@ type Config struct {
 
 // ConfigHeaders defines the headers to use for the different values.
 type ConfigHeaders struct {
+	Version string `json:"version,omitempty"`
 	Cipher string `json:"cipher,omitempty"`
 }
 
@@ -49,6 +50,9 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 }
 
 func (a *TLSHeadersPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if a.headers.Version != "" && req.TLS != nil {
+		req.Header.Set(a.headers.Version, tls.VersionName(req.TLS.Version))
+	}
 	if a.headers.Cipher != "" && req.TLS != nil {
 		req.Header.Set(a.headers.Cipher, tls.CipherSuiteName(req.TLS.CipherSuite))
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -19,7 +19,7 @@ type Config struct {
 // ConfigHeaders defines the headers to use for the different values.
 type ConfigHeaders struct {
 	Version string `json:"version,omitempty"`
-	Cipher string `json:"cipher,omitempty"`
+        Cipher  string `json:"cipher,omitempty"`
 }
 
 // CreateConfig creates the default plugin configuration.

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -17,6 +17,38 @@ func TestInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestTLSVersion(t *testing.T) {
+	cfg := CreateConfig()
+	cfg.Headers.Version = "X-Tls-Version"
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		assertHeader(t, r.Header, "X-Tls-Version", "TLS 1.3")
+	})
+	handler, err := New(context.Background(), next, cfg, "traefik-tls-headers-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewTLSServer(handler)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := server.Client()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}(resp.Body)
+}
+
 func TestTLSCipher(t *testing.T) {
 	cfg := CreateConfig()
 	cfg.Headers.Cipher = "X-Tls-Cipher"

--- a/readme.md
+++ b/readme.md
@@ -13,10 +13,12 @@ middlewares:
     plugin:
       tlsheaders:
         headers:
+          version: X-Tls-Version
           cipher: X-Tls-Cipher
 ```
 
 ## Supported fields
+- `version`: The TLS version used for the connection. See the docs [VersionName](https://pkg.go.dev/crypto/tls#VersionName) for more information.
 - `cipher`: The cipher used for the connection. See the docs [CipherSuiteName](https://pkg.go.dev/crypto/tls#CipherSuiteName) for more information.
 
 ### Configuration
@@ -67,6 +69,7 @@ spec:
   plugin:
     tlsheaders:
       headers:
+        version: X-Tls-Version
         cipher: X-Tls-Cipher
 ```
 
@@ -91,13 +94,14 @@ The traefik test configuration is located in the testconfig directory.
 And finally, make a request to the Traefik instance:
 
 ```bash
-curl -sS https://localhost -k | grep X-Tls-Cipher
+curl -sS https://localhost -k | grep X-Tls
 ```
 
 The response should contain the header(s) you set up.
 
 ```
 X-Tls-Cipher: TLS_AES_128_GCM_SHA256
+X-Tls-Version: TLS 1.3
 ```
 
 ## Credits

--- a/testconfig/dynamic.yml
+++ b/testconfig/dynamic.yml
@@ -19,4 +19,5 @@ http:
       plugin:
         tlsheaders:
           headers:
+            version: X-Tls-Version
             cipher: X-Tls-Cipher


### PR DESCRIPTION
Hi, I am aware that there's a 1-to-1 map between the Cipher and the Version, but I'd like to not maintain a copy of such map in the upstream app that consumes the header; the GO one should be enough and it's always up-to-date.